### PR TITLE
Closes #12, Closes #4  feature: lineWidth

### DIFF
--- a/Example/MRLCircleChart/Base.lproj/Main.storyboard
+++ b/Example/MRLCircleChart/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -22,17 +22,14 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mDV-Ut-tyj" customClass="Chart" customModule="MRLCircleChart">
                                 <rect key="frame" x="8" y="28" width="584" height="475"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="innerRadius">
-                                        <real key="value" value="50"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="outerRadius">
-                                        <real key="value" value="80"/>
-                                    </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="beginColor">
                                         <color key="value" red="0.209107905626297" green="0.79666560888290405" blue="0.46999216079711914" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="endColor">
                                         <color key="value" red="0.46295839548110962" green="0.15626868605613708" blue="0.73675453662872314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="lineWidth">
+                                        <real key="value" value="32"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>

--- a/Pod/Classes/ChartView.swift
+++ b/Pod/Classes/ChartView.swift
@@ -121,18 +121,19 @@ public class Chart: UIView {
     let squareSide = min(frame.size.width, frame.size.height)
     let squaredBounds = CGRect(origin: CGPointZero, size: CGSize(width: squareSide, height: squareSide))
 
-    chartContainer.bounds = squaredBounds
-    chartContainer.center = bounds.center()
-
     if chartContainer.superview == nil {
       chartContainer.transform = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
-
       addSubview(chartContainer)
+    }
 
-      if chartBackgroundSegment == nil {
-        chartBackgroundSegment = SegmentLayer(frame: chartContainer.frame, start: 0, end: CGFloat(M_PI * 2), lineWidth: lineWidth, color: chartBackgroundColor.CGColor)
-        self.layer.insertSublayer(chartBackgroundSegment!, below: chartContainer.layer)
-      }
+    chartContainer.bounds = squaredBounds
+    chartContainer.center = bounds.center()
+    
+    if let backgroundSegment = chartBackgroundSegment {
+      backgroundSegment.frame = chartContainer.bounds
+    } else {
+      chartBackgroundSegment = SegmentLayer(frame: chartContainer.bounds, start: 0, end: CGFloat(M_PI * 2), lineWidth: lineWidth, color: chartBackgroundColor.CGColor)
+      chartContainer.layer.insertSublayer(chartBackgroundSegment!, atIndex:0)
     }
 
     for layer in chartSegmentLayers {

--- a/Pod/Classes/ChartView.swift
+++ b/Pod/Classes/ChartView.swift
@@ -30,8 +30,7 @@ import UIKit
 private enum ChartProperties {
   static let dataSourceKey = "dataSource"
   static let maxAngleKey = "maxAngle"
-  static let innerRadiusKey = "innerRadius"
-  static let outerRadiusKey = "outerRadius"
+  static let lineWidthKey = "lineWidth"
 }
 
 /**
@@ -51,8 +50,7 @@ public class Chart: UIView {
 
   //MARK: - Public Inspectables
 
-  @IBInspectable public var innerRadius: CGFloat = 0
-  @IBInspectable public var outerRadius: CGFloat = 0
+  @IBInspectable public var lineWidth: CGFloat = 25
   @IBInspectable public var chartBackgroundColor: UIColor = UIColor(white: 0.7, alpha: 0.66)
   @IBInspectable public var beginColor: UIColor?
   @IBInspectable public var endColor: UIColor?
@@ -62,8 +60,6 @@ public class Chart: UIView {
   private let chartContainer = UIView()
   private var chartBackgroundSegment: SegmentLayer?
   private var chartSegmentLayers: [SegmentLayer] = []
-  private var outerRadiusRatio: CGFloat = 0.0
-  private var innerRadiusRatio: CGFloat = 0.0
   private var colorPallette: [UIColor] = []
   private var grayscalePallette: [UIColor] = []
 
@@ -82,10 +78,7 @@ public class Chart: UIView {
    - parameter frame:       frame used to display the chart view; since chart
    itself requires square bounds, the greates square frame that fits in the
    frame is derived and centered in chart frame
-   - parameter innerRadius: if larger than 0, defines the radius of an inner
-   'hole' in the chart
-   - parameter outerRadius: defines the outer radius of the chart, should be
-   greater than `innerRadius`
+   - parameter lineWidth:   the width of chart's line
    - parameter dataSource:  `DataSource` complying object that provides all
    data details for the chart view
    - parameter beginColor:  color of the first chart segment layer
@@ -93,9 +86,8 @@ public class Chart: UIView {
 
    - returns: fully configured chart view
    */
-  public required init(frame: CGRect, innerRadius: CGFloat, outerRadius: CGFloat, dataSource: DataSource, beginColor: UIColor = UIColor.greenColor(), endColor: UIColor = UIColor.yellowColor()) {
-    self.innerRadius = innerRadius
-    self.outerRadius = outerRadius
+  public required init(frame: CGRect, lineWidth: CGFloat, dataSource: DataSource, beginColor: UIColor = UIColor.greenColor(), endColor: UIColor = UIColor.yellowColor()) {
+    self.lineWidth = lineWidth
     self.dataSource = dataSource
     self.beginColor = beginColor
     self.endColor = endColor
@@ -138,18 +130,9 @@ public class Chart: UIView {
       addSubview(chartContainer)
 
       if chartBackgroundSegment == nil {
-        chartBackgroundSegment = SegmentLayer(frame: chartContainer.frame, start: 0, end: CGFloat(M_PI * 2), outerRadius: outerRadius, innerRadius: innerRadius, color: chartBackgroundColor.CGColor)
+        chartBackgroundSegment = SegmentLayer(frame: chartContainer.frame, start: 0, end: CGFloat(M_PI * 2), lineWidth: lineWidth, color: chartBackgroundColor.CGColor)
         self.layer.insertSublayer(chartBackgroundSegment!, below: chartContainer.layer)
       }
-
-    }
-
-    if outerRadiusRatio == 0 {
-      outerRadiusRatio = outerRadius / (chartContainer.frame.size.width / 2)
-    }
-
-    if innerRadiusRatio == 0 {
-      innerRadiusRatio = innerRadius / (chartContainer.frame.size.width / 2)
     }
 
     for layer in chartSegmentLayers {
@@ -212,8 +195,7 @@ public class Chart: UIView {
           frame: chartContainer.bounds,
           start: source.startAngle(index),
           end: source.endAngle(index),
-          outerRadius: outerRadius,
-          innerRadius: innerRadius,
+          lineWidth: lineWidth,
           color: colorPallette[index].CGColor
         )
         chartContainer.layer.addSublayer(layer)
@@ -289,7 +271,7 @@ public class Chart: UIView {
     }
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(0.25 * Double(NSEC_PER_SEC))), dispatch_get_main_queue(), {
-      let segment = SegmentLayer(frame: self.chartContainer.bounds, start: 0, end: fromAngle, outerRadius: self.outerRadius, innerRadius: self.innerRadius, color: color.CGColor)
+      let segment = SegmentLayer(frame: self.chartContainer.bounds, start: 0, end: fromAngle, lineWidth: self.lineWidth, color: color.CGColor)
       segment.capType = .BothEnds
       segment.animationDuration = duration
 
@@ -402,7 +384,7 @@ public class Chart: UIView {
     case .Grow:
       for layer in chartSegmentLayers {
         layer.selected = layer.containsPoint(point) ? !layer.selected : false
-        layer.outerRadius = layer.selected ? outerRadius + 20 : outerRadius
+        layer.lineWidth = layer.selected ? lineWidth + 20 : lineWidth
       }
       break
     case .DesaturateNonSelected:

--- a/Pod/Classes/SegmentLayer.swift
+++ b/Pod/Classes/SegmentLayer.swift
@@ -36,8 +36,7 @@ class SegmentLayer: CALayer {
   struct PropertyKeys {
     static let startAngleKey = "startAngle"
     static let endAngleKey = "endAngle"
-    static let innerRadiusKey = "innerRadius"
-    static let outerRadiusKey = "outerRadius"
+    static let lineWidthKey = "lineWidth"
     static let colorKey = "color"
     static let capType = "capType"
 
@@ -45,8 +44,7 @@ class SegmentLayer: CALayer {
       colorKey,
       startAngleKey,
       endAngleKey,
-      innerRadiusKey,
-      outerRadiusKey
+      lineWidthKey
     ]
   }
   /**
@@ -60,8 +58,7 @@ class SegmentLayer: CALayer {
 
   @NSManaged var startAngle: CGFloat
   @NSManaged var endAngle: CGFloat
-  @NSManaged var innerRadius: CGFloat
-  @NSManaged var outerRadius: CGFloat
+  @NSManaged var lineWidth: CGFloat
   @NSManaged var color: CGColorRef
 
   var animationDuration: Double = Constants.animationDuration
@@ -81,21 +78,19 @@ class SegmentLayer: CALayer {
    frame should be identical for all chart segments.
    - parameter start:       angle at which to begin drawing
    - parameter end:         angle at which to stop drawing
-   - parameter outerRadius: radius of the outer border
-   - parameter innerRadius: radius of the inner border, used to 'punch a hole' in the center of the chart, can be 0 for a full chart
+   - parameter lineWidth:   chart's width
    - parameter color:       `CGColorRef` color of the segment
 
    - returns: a fully configured `SegmentLayer` instance
    */
 
-  required init(frame: CGRect, start: CGFloat, end: CGFloat, outerRadius: CGFloat, innerRadius: CGFloat, color: CGColorRef) {
+  required init(frame: CGRect, start: CGFloat, end: CGFloat, lineWidth: CGFloat, color: CGColorRef) {
     super.init()
 
     self.frame = frame
     self.startAngle = start
     self.endAngle = end
-    self.outerRadius = outerRadius
-    self.innerRadius = innerRadius
+    self.lineWidth = lineWidth
     self.color = color
 
     self.commonInit()
@@ -103,15 +98,6 @@ class SegmentLayer: CALayer {
 
   override init(layer: AnyObject) {
     super.init(layer: layer)
-
-    if layer.isKindOfClass(SegmentLayer) {
-      self.startAngle = layer.startAngle
-      self.endAngle = layer.endAngle
-      self.outerRadius = layer.outerRadius
-      self.innerRadius = layer.innerRadius
-      self.color = layer.color
-      self.capType = layer.capType
-    }
     self.commonInit()
   }
 
@@ -147,8 +133,7 @@ class SegmentLayer: CALayer {
   override func actionForKey(event: String) -> CAAction? {
 
     let shouldSkipAnimationOnEntry = superlayer == nil
-      && (PropertyKeys.outerRadiusKey == event
-      || PropertyKeys.innerRadiusKey == event)
+      && (PropertyKeys.lineWidthKey == event)
 
     if event == PropertyKeys.colorKey {
       return animationForColor()
@@ -277,6 +262,9 @@ class SegmentLayer: CALayer {
 
     let pointOnCircle = point(center)
 
+    let outerRadius = bounds.width / 2
+    let innerRadius = outerRadius - lineWidth
+    
     let innerStartPoint = pointOnCircle(innerRadius, startAngle)
     let outerStartPoint = pointOnCircle(outerRadius, startAngle)
     let innerEndPoint = pointOnCircle(innerRadius, endAngle)

--- a/Pod/Classes/SegmentLayer.swift
+++ b/Pod/Classes/SegmentLayer.swift
@@ -39,6 +39,7 @@ class SegmentLayer: CALayer {
     static let lineWidthKey = "lineWidth"
     static let colorKey = "color"
     static let capType = "capType"
+    static let boundsKey = "bounds"
 
     static let animatableProperties = [
       colorKey,
@@ -127,9 +128,8 @@ class SegmentLayer: CALayer {
 
    - parameter event: String corresponding to the property key
 
-   - returns: a custom animation for specified properties or `nil` for everything
-   else
-   */
+   - returns: a custom animation for specified properties
+  */
   override func actionForKey(event: String) -> CAAction? {
 
     let shouldSkipAnimationOnEntry = superlayer == nil
@@ -146,7 +146,7 @@ class SegmentLayer: CALayer {
       return animationForAngle(event)
     }
 
-    return nil//super.actionForKey(event)
+    return super.actionForKey(event)
   }
 
   /**
@@ -227,7 +227,8 @@ class SegmentLayer: CALayer {
 
   override class func needsDisplayForKey(key: String) -> Bool {
     if PropertyKeys.animatableProperties.contains(key)
-      || key == PropertyKeys.capType {
+      || key == PropertyKeys.capType
+      || key == PropertyKeys.boundsKey {
       return true
     }
     return super.needsDisplayForKey(key)

--- a/Pod/Classes/SegmentLayer.swift
+++ b/Pod/Classes/SegmentLayer.swift
@@ -117,13 +117,6 @@ class SegmentLayer: CALayer {
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-
-    self.color = aDecoder.decodeCGColorRefForKey(PropertyKeys.colorKey)
-    self.startAngle = CGFloat(aDecoder.decodeFloatForKey(PropertyKeys.startAngleKey))
-    self.endAngle = CGFloat(aDecoder.decodeFloatForKey(PropertyKeys.endAngleKey))
-    self.outerRadius = CGFloat(aDecoder.decodeFloatForKey(PropertyKeys.outerRadiusKey))
-    self.innerRadius = CGFloat(aDecoder.decodeFloatForKey(PropertyKeys.innerRadiusKey))
-
     self.commonInit()
   }
 
@@ -136,11 +129,7 @@ class SegmentLayer: CALayer {
   }
 
   override func encodeWithCoder(aCoder: NSCoder) {
-    aCoder.encodeFloat(Float(startAngle), forKey: PropertyKeys.startAngleKey)
-    aCoder.encodeFloat(Float(endAngle), forKey: PropertyKeys.endAngleKey)
-    aCoder.encodeFloat(Float(outerRadius), forKey: PropertyKeys.outerRadiusKey)
-    aCoder.encodeFloat(Float(innerRadius), forKey: PropertyKeys.innerRadiusKey)
-    aCoder.encodeCGColorRef(self.color, key: PropertyKeys.colorKey)
+    super.encodeWithCoder(aCoder)
   }
 
   //MARK: - Animation Overrides
@@ -247,12 +236,8 @@ class SegmentLayer: CALayer {
   func animateInsertion(startAngle: CGFloat, endAngle: CGFloat? = nil) {
     let initialEndAngle = endAngle == nil ? startAngle : endAngle!
 
-    CATransaction.begin()
-
     self.addAnimation(animation(PropertyKeys.startAngleKey, toValue: self.startAngle, fromValue: startAngle), forKey: PropertyKeys.startAngleKey)
     self.addAnimation(animation(PropertyKeys.endAngleKey, toValue: self.endAngle, fromValue: initialEndAngle), forKey: PropertyKeys.endAngleKey)
-
-    CATransaction.commit()
   }
 
   override class func needsDisplayForKey(key: String) -> Bool {


### PR DESCRIPTION
*warning: breaks compatibility with 0.2.0*

resolves #12 by replacing `innerRadius` and `outerRadius` properties in both `SegmentLayer` and `Chart` with a single `lineWidth` property

additionally, resolves #4 by relying on `bounds` width to draw the lineWidth